### PR TITLE
VEGA-167: Убрать команду git add из настроек lint-stage

### DIFF
--- a/git/lint-staged.config.js
+++ b/git/lint-staged.config.js
@@ -1,5 +1,5 @@
 module.exports = {
   "*.{js,jsx,ts,tsx}": ["eslint --fix"],
   "*.css": ["stylelint --fix"],
-  "*.{json,md}": ["prettier --write"],
+  "*.{js,jsx,ts,tsx, json,md}": ["prettier --write"],
 };

--- a/git/lint-staged.config.js
+++ b/git/lint-staged.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  '*.{js,jsx,ts,tsx}': ['eslint --fix', 'git add'],
-  '*.css': ['stylelint --fix', 'git add'],
-  '*.{json,md}': ['prettier --write', 'git add'],
+  "*.{js,jsx,ts,tsx}": ["eslint --fix"],
+  "*.css": ["stylelint --fix"],
+  "*.{json,md}": ["prettier --write"],
 };


### PR DESCRIPTION
[VEGA-167](https://jira.csssr.io/browse/VEGA-167)

нужно удалить, чтобы исключить двойного выполнения команды `git add`