### PR TITLE
fix(eslint): игнорировать правило no-underscore-dangle для __typename

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -86,6 +86,7 @@ module.exports = {
     ],
     'no-confusing-arrow': ['error', { allowParens: false }],
     'no-redeclare': ['error', { builtinGlobals: false }],
+    'no-underscore-dangle': ['error', { allow: ['__typename'] }],
     'simple-import-sort/sort': [
       'error',
       {


### PR DESCRIPTION
## Описание изменений
Исключил поле `__typename` из правила `no-underscore-dangle` 

## Чек-лист

- [x] PR: направлен в правильную ветку
- [x] PR: назначен исполнитель PR и указаны нужные лейблы
- [x] PR: проверен diff, ничего лишнего в PR не попало
- [x] PR: есть описание изменений или приложена ссылка на задачу с описанием, оставлены пояснительные комментарии к diff
- [ ] Документация: отражены все изменения в API конфигов и описаны важные особенности реализации или использования
- [x] Конфигурационные файлы: новые файлы или изменения текущих были проверены в тестовых репозиториях
## Опционально

- [ ] PR: прилинкованы затронутые issue и связанные PR
- [ ] Доработки: заведены задачи для дальнейшей работы, если что-то решено не править в текущем PR
- [ ] Коммиты: проименованы в соответствии с [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
